### PR TITLE
Remove deprecated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,8 +8,6 @@
   "noarg": true,
   "onevar": true,
   "quotmark": "double",
-  "smarttabs": true,
-  "trailing": true,
   "undef": true,
   "unused": true,
   "globals": { 


### PR DESCRIPTION
The `smarttabs` and `trailing` JSHint options are removed since JSHint v2.5
