### PR TITLE
add version info as a comment to dist files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,13 @@
 'use strict';
 
+var path = require('path');
 var gulp = require('gulp');
-
+var pkg = require('./package');
 var $ = require('gulp-load-plugins')();
+
+function version(file){
+   return '/* ' + path.basename(file.path) + ' ' + pkg.version + ' */\n';
+}
 
 gulp.task('build', function () {
   return gulp.src('./src/_wrapper.js')
@@ -10,6 +15,7 @@ gulp.task('build', function () {
     .pipe($.rename('cash.js'))
     .pipe($.size())
     .pipe($.beautify())
+    .pipe($.tap(function(file, t) { file.contents = Buffer.concat([new Buffer(version(file)), file.contents]);}))
     .pipe(gulp.dest('./dist/'));
 });
 
@@ -18,6 +24,7 @@ gulp.task('minify', ['build'], function () {
     .pipe($.uglify())
     .pipe($.size())
     .pipe($.rename("cash.min.js"))
+    .pipe($.tap(function(file, t) { file.contents = Buffer.concat([new Buffer(version(file)), file.contents]);}))
     .pipe(gulp.dest('./dist/'));
 });
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp-preprocess": "^1.1.1",
     "gulp-rename": "^1.2.0",
     "gulp-size": "~0.1.2",
+    "gulp-tap": "^0.1.3",
     "gulp-uglify": "~1.0.1",
     "gulp-util": "~2.2.9",
     "gulp-wrap": "~0.3.0"


### PR DESCRIPTION
This PR adds a single comment to the top of the generated dist files with the version number of the package.

Currently it would add:
```
/* cash.js 0.0.3 */
```
and
```
/* cash.min.js 0.0.3 */
```

I think this is useful information, but if you think it's unnecessary feel free to close out the PR :)

Note I didn't submit the PR with the gulp task run as it was updating the actual library code from the latest commits post version 0.0.3
