### PR TITLE
Add semicolon.

### DIFF
--- a/src/_wrapper.js
+++ b/src/_wrapper.js
@@ -1,5 +1,5 @@
 // @echo header
-(function(root, factory) {
+;(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     define(factory);
   } else if (typeof exports !== 'undefined') {


### PR DESCRIPTION
Prevent errors when appending the file during concatenation to a file containing an expression not properly terminated with a `;`

For more details: http://stackoverflow.com/q/1873983/4260745