### PR TITLE
Test only against node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 dist: trusty
-node_js:
-  - 8
-  - 10
+node_js: lts/*
 
 addons:
   chrome: stable


### PR DESCRIPTION
`cash` is the client-side library, I don't think that testing in multiple versions of Node.js is improving something for client-side libraries.

We are testing `cash` against multiple operating systems and browsers via SauceLabs (#208), but testing against multiple Node.js versions is excessive.