### PR TITLE
fix(saucelabs): use IE11 on Windows 8.1

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,8 +13,8 @@ const SauceLabsLaunchers = {
   sauce_ie_11: {
     base: 'SauceLabs',
     browserName: 'internet explorer',
-    version: '11.103',
-    platform: 'Windows 10'
+    version: '11.0',
+    platform: 'Windows 8.1'
   },
   sauce_edge_15: {
     base: 'SauceLabs',


### PR DESCRIPTION
Fix for https://travis-ci.org/kenwheeler/cash/builds/440690608

![image](https://user-images.githubusercontent.com/6059356/46880126-7d518480-ce50-11e8-804b-958ccd2171b7.png)

Tested locally with my Sauce credentials, works nicely 👍 