### PR TITLE
Add travis_retry to tests with SauceLabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - xvfb-run karma start --single-run
 
   - if [[ "$TRAVIS_EVENT_TYPE" = "push" ]]; then
-      karma start --single-run --sauce;
+      travis_retry karma start --single-run --sauce;
     fi;
 
 notifications:


### PR DESCRIPTION
SauceLabs randomly returns error 502: 

```
14 10 2018 23:14:06.323:ERROR [launcher.sauce]: Can not start internet explorer 10.0 (Windows 7)
  Failed to start Sauce Connect:
  Download failed with status code: 502
```

https://travis-ci.org/kenwheeler/cash/builds/441427819

Unfortunately, I don't have a good solution for this, it's totally on their side, but with `travis_retry` we can decrease falsy failures by retrying SauceLabs tests up to 3 times.

Docs: https://docs.travis-ci.com/user/common-build-problems/#travis_retry