### PR TITLE
Add Firefox tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 dist: trusty
 addons:
   chrome: stable
+  firefox: latest
 
 language: node_js
 node_js: lts/*

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -98,6 +98,7 @@ function config ( config ) {
     plugins: [
       'karma-qunit',
       'karma-chrome-launcher',
+      'karma-firefox-launcher',
       'karma-sauce-launcher',
       'karma-spec-reporter'
     ],
@@ -105,7 +106,7 @@ function config ( config ) {
       'dist/cash.js',
       'test/index.js'
     ],
-    browsers: isSauceLabs ? Object.keys ( SauceLabsLaunchers ) : ['Chrome'],
+    browsers: isSauceLabs ? Object.keys ( SauceLabsLaunchers ) : ['Chrome', 'Firefox'],
     customLaunchers: SauceLabsLaunchers,
     reporters: [
       'spec',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jquery": "^3.3.1",
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-qunit": "^2.1.0",
     "karma-sauce-launcher": "^1.2.0",
     "karma-spec-reporter": "0.0.32",


### PR DESCRIPTION
For some reason we're currently testing outdated versions of Firefox in SauceLabs. Any particular reason for that?

What is hte version range of supported Firefox versions? Usually it's two latest versions which at the moment means 61 and 62.

This PR will add tests against Firefox Beta which is currently `v63`.