### PR TITLE
Add bundlesize to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - npm run build:prod
 
 script:
+  - bundlesize -f dist/cash.min.js -s 5kB
   # xvfb-run is needed for headless testing with real browsers
   - xvfb-run karma start --single-run
   - if [[ "$TRAVIS_EVENT_TYPE" = "push" ]]; then

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {},
   "devDependencies": {
     "browser-sync": "^2.26.3",
+    "bundlesize": "^0.17.0",
     "jquery": "^3.3.1",
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^2.2.0",


### PR DESCRIPTION
The fat code shall not pass! :D

The bundlesize repo and docs: https://github.com/siddharthkp/bundlesize

There's a possibility to have a lovely GitHub status notification: https://github.com/siddharthkp/bundlesize#2-build-status

![image](https://user-images.githubusercontent.com/6059356/47359962-b999a600-d6d6-11e8-97a1-410f466ef663.png)

In order to have that, `BUNDLESIZE_GITHUB_TOKEN` env variable should be added to Travis config.