### PR TITLE
Remove node_modules cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ addons:
 language: node_js
 node_js: lts/*
 
-cache:
-  directories:
-    - "node_modules"
-
 install:
   - npm install
   - npm run build:prod


### PR DESCRIPTION
Fixes #232 

Node's LTS has benn upgraded from 8 to 10, caching `node_modules` is a bad practice IMO because from time to time the manual work (clearing cache) will be required. The manual work is a bug, and the speed-up of using cache is insignificant. 