### PR TITLE
SauceLabs: replaced iOS 10.3 with iOS 11.0

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -64,11 +64,11 @@ const SauceLabsLaunchers = {
     version: 'latest',
     platform: 'macOS 10.13'
   },
-  ios_10: {
+  ios_11: {
     base: 'SauceLabs',
     deviceName: 'iPhone 6 Simulator',
     browserName: 'Safari',
-    platformVersion: '10.3',
+    platformVersion: '11.0',
     platformName: 'iOS'
   },
   ios_12: {


### PR DESCRIPTION
Unfortunately, iOS 10.3 doesn't seem to work. I tried different versions of appium, different iPhone versions, even iPad, no luck.

11.0 works as expected

Closes #283 