### PR TITLE
Add web field to package.json to support Webpack defaults for bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "An absurdly small jQuery alternative for modern browsers.",
   "version": "4.1.2",
   "license": "MIT",
+  "web": "./dist/cash.js",
   "main": "./dist/cash.js",
   "module": "./dist/cash.esm.js",
   "jsnext:main": "./dist/cash.esm.js",


### PR DESCRIPTION
As discussed on https://github.com/kenwheeler/cash/issues/268, this supports Webpack's default `mainFields` for "web" target: `["web", "module", "main"]`, allowing `cash` to be bundled into a Webpack bundle with no further configuration and still support IE10+.