### PR TITLE
Fix prepend.

### DIFF
--- a/src/manipulation/prepend.ts
+++ b/src/manipulation/prepend.ts
@@ -8,8 +8,8 @@ interface Cash {
 }
 
 Cash.prototype.prepend = function ( this: Cash ) {
-  each ( arguments, ( i, selector: Selector ) => {
-    insertContent ( this, cash ( selector ), true );
+  each ( reverse.apply( arguments ), ( i, selector: Selector ) => {
+    insertContent ( this, reverse.apply( cash ( selector ) ), true );
   });
   return this;
 };


### PR DESCRIPTION
Adds elements in the correct order no matter which arguments are passed in, for example:

$( 'div' ).prepend( '&lt;p&gt;1st paragraph&lt;/p&gt;&lt;p&gt;2nd paragraph&lt;/p&gt;', '&lt;p&gt;3rd paragraph&lt;/p&gt;', '&lt;p&gt;4th paragraph&lt;/p&gt;&lt;/p&gt;5th paragraph&lt;/p&gt;' );