### PR TITLE
fix(core): only clone the own properties instead of all possible prototype properties

### DIFF
--- a/src/core/extend.ts
+++ b/src/core/extend.ts
@@ -22,9 +22,13 @@ function extend ( target?: any, ...objs: any[] ) {
   for ( let i = 1; i < length; i++ ) {
 
     for ( const key in arguments[i] ) {
-      if (arguments[i].hasOwnProperty(key)) {
+
+      if ( arguments[i].hasOwnProperty( key ) ) {
+
         target[key] = arguments[i][key];
+
       }
+
     }
 
   }

--- a/src/core/extend.ts
+++ b/src/core/extend.ts
@@ -22,9 +22,9 @@ function extend ( target?: any, ...objs: any[] ) {
   for ( let i = 1; i < length; i++ ) {
 
     for ( const key in arguments[i] ) {
-
-      target[key] = arguments[i][key];
-
+      if (arguments[i].hasOwnProperty(key)) {
+        target[key] = arguments[i][key];
+      }
     }
 
   }


### PR DESCRIPTION
## Description
I am currently investigating into replacing jquery by cash in our https://github.com/fomantic/Fomantic-UI ( because everyone is moaning about it ) and came across this while testing:

Whenever the `extend`  method is used, it should make sure to only extend the own properties instead of all possible prototype functions as well