### PR TITLE
Performance improvement to the `hide` method

### DIFF
--- a/src/effects/toggle.ts
+++ b/src/effects/toggle.ts
@@ -16,8 +16,7 @@ fn.toggle = function ( this: Cash, force?: boolean ) {
 
     if ( !isElement ( ele ) ) return;
 
-    const hidden = isHidden ( ele );
-    const show = isUndefined ( force ) ? hidden : force;
+    const show = isUndefined ( force ) ? isHidden ( ele ) : force;
 
     if ( show ) {
 
@@ -29,9 +28,9 @@ fn.toggle = function ( this: Cash, force?: boolean ) {
 
       }
 
-    } else if ( !hidden ) {
+    } else if ( ele.style.display !== 'none' ) {
 
-      ele[displayProperty] = computeStyle ( ele, 'display' );
+      ele[displayProperty] = ele.style.display;
 
       ele.style.display = 'none';
 

--- a/src/effects/toggle.ts
+++ b/src/effects/toggle.ts
@@ -17,20 +17,25 @@ fn.toggle = function ( this: Cash, force?: boolean ) {
     if ( !isElement ( ele ) ) return;
 
     const show = isUndefined ( force ) ? isHidden ( ele ) : force;
+    const display = ele.style.display;
 
     if ( show ) {
 
-      ele.style.display = ele[displayProperty] || '';
+      if ( !display || display === 'none' ) {
 
-      if ( isHidden ( ele ) ) {
+        ele.style.display = ele[displayProperty] || '';
 
-        ele.style.display = getDefaultDisplay ( ele.tagName );
+        if ( isHidden ( ele ) ) {
+
+          ele.style.display = getDefaultDisplay ( ele.tagName );
+
+        }
 
       }
 
-    } else if ( ele.style.display !== 'none' ) {
+    } else if ( display !== 'none' ) {
 
-      ele[displayProperty] = ele.style.display;
+      ele[displayProperty] = display;
 
       ele.style.display = 'none';
 

--- a/test/modules/effects.js
+++ b/test/modules/effects.js
@@ -66,7 +66,7 @@ describe ( 'Effects', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
       ele.hide ().show ();
 
-      t.is ( ele[0].style.display, 'inline-block' );
+      t.is ( ele.css ( 'display' ), 'inline-block' );
 
     });
 

--- a/test/modules/effects.js
+++ b/test/modules/effects.js
@@ -12,7 +12,7 @@ var fixture = '\
   <span class="toggleable hide-cls"></span>\
   <span class="show-custom"></span>\
   <span class="show-custom-style"></span>\
-  <span class="shown-with-inline-css-and-hidden-in-styles hide-cls" style="display: block"></span>\
+  <span class="span-with-display-block" style="display: block"></span>\
 ';
 
 function isDisplay ( collection, display ) {
@@ -97,9 +97,9 @@ describe ( 'Effects', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
     });
 
-    it ( 'supports showing already visible item', function ( t ) {
+    it ( 'does not changing display for already visible item', function ( t ) {
 
-      var eles = $('.shown-with-inline-css-and-hidden-in-styles');
+      var eles = $('.span-with-display-block');
 
       eles.show ();
 

--- a/test/modules/effects.js
+++ b/test/modules/effects.js
@@ -12,6 +12,7 @@ var fixture = '\
   <span class="toggleable hide-cls"></span>\
   <span class="show-custom"></span>\
   <span class="show-custom-style"></span>\
+  <span class="shown-with-inline-css-and-hidden-in-styles hide-cls" style="display: block"></span>\
 ';
 
 function isDisplay ( collection, display ) {
@@ -93,6 +94,16 @@ describe ( 'Effects', { beforeEach: getFixtureInit ( fixture ) }, function () {
       t.is ( title.css ( 'display' ), 'block' );
 
       title.detach ();
+
+    });
+
+    it ( 'supports showing already visible item', function ( t ) {
+
+      var eles = $('.shown-with-inline-css-and-hidden-in-styles');
+
+      eles.show ();
+
+      t.true ( isDisplay ( eles, 'block' ) );
 
     });
 


### PR DESCRIPTION
This PR removes unnecessary style recalculation when using the `hide` method. I faced a performance issue when started calling  `hide` on thousands of elements.

The improvement is made by getting rid of `computeStyle` usage when calling `hide` and using `ele.style.display` only. Because it doesn't matter what `display` value was before hiding, if `display` is not inside the inline style attribute.

Here is the jQuery implementation I used as a reference: https://github.com/jquery/jquery/blob/main/src/css/showHide.js#L44-L65

Here are the screenshots before PR (Total scripting 4x slowdown: 5 seconds):

Zoomed out | Zoomed in
-----------------|--------------------
![Screenshot from 2024-12-20 09-38-42](https://github.com/user-attachments/assets/46851ab9-39f1-4c4f-bdcc-7fcd15a86920) | ![Screenshot from 2024-12-20 09-39-03](https://github.com/user-attachments/assets/8d005891-abe8-480f-abf8-7c571f951120)

Here are the screenshots after PR (Total scripting 4x slowdown: 1 second):

Zoomed out | Zoomed in
-----------------|--------------------
![Screenshot from 2024-12-20 09-41-40](https://github.com/user-attachments/assets/c4c64e35-e820-41ad-8635-0ce18a94c1cd) | ![Screenshot from 2024-12-20 09-42-03](https://github.com/user-attachments/assets/0262f8e9-72b5-42ea-8c2b-cbdbb5856dab)
