### PR TITLE
Allow passing text the the manipulation functions

### DIFF
--- a/src/effects/toggle.ts
+++ b/src/effects/toggle.ts
@@ -16,22 +16,26 @@ fn.toggle = function ( this: Cash, force?: boolean ) {
 
     if ( !isElement ( ele ) ) return;
 
-    const hidden = isHidden ( ele );
-    const show = isUndefined ( force ) ? hidden : force;
+    const show = isUndefined ( force ) ? isHidden ( ele ) : force;
+    const display = ele.style.display;
 
     if ( show ) {
 
-      ele.style.display = ele[displayProperty] || '';
+      if ( !display || display === 'none' ) {
 
-      if ( isHidden ( ele ) ) {
+        ele.style.display = ele[displayProperty] || '';
 
-        ele.style.display = getDefaultDisplay ( ele.tagName );
+        if ( isHidden ( ele ) ) {
+
+          ele.style.display = getDefaultDisplay ( ele.tagName );
+
+        }
 
       }
 
-    } else if ( !hidden ) {
+    } else if ( display !== 'none' ) {
 
-      ele[displayProperty] = computeStyle ( ele, 'display' );
+      ele[displayProperty] = display;
 
       ele.style.display = 'none';
 

--- a/src/manipulation/after.ts
+++ b/src/manipulation/after.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   after ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.after = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, false, false, true, true );
+  return insertContent ( arguments, this, false, false, false, true, true );
 
 };

--- a/src/manipulation/append.ts
+++ b/src/manipulation/append.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   append ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.append = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, false, true );
+  return insertContent ( arguments, this, false, false, true );
 
 };

--- a/src/manipulation/before.ts
+++ b/src/manipulation/before.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   before ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.before = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, true );
+  return insertContent ( arguments, this, false, true );
 
 };

--- a/src/manipulation/helpers/insert_content.ts
+++ b/src/manipulation/helpers/insert_content.ts
@@ -1,0 +1,12 @@
+
+// @require ./insert_selectors.ts
+
+function insertContent<T extends ArrayLike<EleLoose> = ArrayLike<EleLoose>> ( selectors: ArrayLike<Selector>, anchors: T, inverse?: boolean, left?: boolean, inside?: boolean, reverseLoop1?: boolean, reverseLoop2?: boolean, reverseLoop3?: boolean ): T {
+
+  if (!isCash ( selectors ) && isString ( selectors[0] ) && !htmlRe.test ( selectors[0] )) {
+    arguments[0] = [doc.createTextNode(selectors[0])];
+  }
+
+  return insertSelectors ( ...arguments );
+
+}

--- a/src/manipulation/prepend.ts
+++ b/src/manipulation/prepend.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   prepend ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.prepend = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, true, true, true, true );
+  return insertContent ( arguments, this, false, true, true, true, true );
 
 };

--- a/test/modules/effects.js
+++ b/test/modules/effects.js
@@ -12,6 +12,7 @@ var fixture = '\
   <span class="toggleable hide-cls"></span>\
   <span class="show-custom"></span>\
   <span class="show-custom-style"></span>\
+  <span class="span-with-display-block" style="display: block"></span>\
 ';
 
 function isDisplay ( collection, display ) {
@@ -66,7 +67,7 @@ describe ( 'Effects', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
       ele.hide ().show ();
 
-      t.is ( ele[0].style.display, 'inline-block' );
+      t.is ( ele.css ( 'display' ), 'inline-block' );
 
     });
 
@@ -93,6 +94,16 @@ describe ( 'Effects', { beforeEach: getFixtureInit ( fixture ) }, function () {
       t.is ( title.css ( 'display' ), 'block' );
 
       title.detach ();
+
+    });
+
+    it ( 'does not changing display for already visible item', function ( t ) {
+
+      var eles = $('.span-with-display-block');
+
+      eles.show ();
+
+      t.true ( isDisplay ( eles, 'block' ) );
 
     });
 

--- a/test/modules/manipulation.js
+++ b/test/modules/manipulation.js
@@ -83,6 +83,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
 
     });
 
+    it ( 'inserts a text after', function ( t ) {
+
+      $('.parent .anchor').after('text');
+
+      t.is($('.parent').html().trim(), '<div class="anchor">content</div>text');
+
+    });
+
     it ( 'supports non-element nodes', function ( t ) {
 
       var ele = $('<div><span> dear</span>world</div>');
@@ -120,6 +128,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
       t.is ( prev.length, 0 );
       t.is ( next.length, 3 );
       t.deepEqual ( $('.parent').children ().slice ( 1 ).get ().map ( ele2tagname ), ['A', 'B', 'C'] );
+
+    });
+
+    it ( 'appends text', function ( t ) {
+
+      $('.parent').append('text');
+
+      t.is($('.parent').html().trim(), '<div class=\"anchor\">content</div>  text');
 
     });
 
@@ -185,6 +201,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
       t.is ( prev.length, 3 );
       t.is ( next.length, 0 );
       t.deepEqual ( $('.parent').children ().slice ( 0, 3 ).get ().map ( ele2tagname ), ['A', 'B', 'C'] );
+
+    });
+
+    it ( 'inserts a text before', function ( t ) {
+
+      $('.parent .anchor').before('text');
+
+      t.is($('.parent').html().trim(), 'text<div class=\"anchor\">content</div>');
 
     });
 
@@ -413,6 +437,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
 
     });
 
+    it ( 'prepends a text', function ( t ) {
+
+      $('.parent').prepend('text');
+
+      t.is($('.parent').html().trim(), 'text    <div class=\"anchor\">content</div>');
+
+    });
+
     it ( 'supports non-element nodes', function ( t ) {
 
       var ele = $('<div>world</div>');
@@ -527,6 +559,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
       t.is ( parent.html ().trim (), html );
       t.is ( $('.anchor').length, 0 );
       t.is ( $('.parent p').length, 1 );
+
+    });
+
+    it ( 'replaces node with a text', function ( t ) {
+
+      $('.parent .anchor').replaceWith('text');
+
+      t.is($('.parent').html().trim(), 'text');
 
     });
 


### PR DESCRIPTION
This PR fixes the ability to pass text to the following functions:

- after
- append
- before
- prepend
- replaceWith

This is a known and documented difference:
- Issue: https://github.com/fabiospampinato/cash/issues/275
- Documentation: https://github.com/fabiospampinato/cash/blob/master/docs/migration_guide.md#manipulation

This is a BC to the Cash library, so version 2.0 is coming.